### PR TITLE
fix(back-end): dotenv should be python-dotenv

### DIFF
--- a/BE/requirements.txt
+++ b/BE/requirements.txt
@@ -4,4 +4,4 @@ langchain==0.2.7
 langchain-community 
 langchain-core
 ctransformers
-dotenv
+python-dotenv


### PR DESCRIPTION
A user on Reddit [reported](https://www.reddit.com/r/jenkinsci/comments/1f3xpen/comment/lkic6ne/) he got an error with `requirements.txt` because of `dotenv`.
Once changed into `python-dotenv`, it worked for him.
Could you please confirm?
Thanks.